### PR TITLE
level-13-readiness - wrong readiness probe port in hint3

### DIFF
--- a/worlds/world-2-deployments/level-13-readiness/hint-3.txt
+++ b/worlds/world-2-deployments/level-13-readiness/hint-3.txt
@@ -12,7 +12,7 @@ Steps:
         readinessProbe:
           httpGet:
             path: /
-            port: 8080
+            port: 80
           initialDelaySeconds: 22  # Wait for the 20s sleep + 2s buffer
           periodSeconds: 5
           successThreshold: 1


### PR DESCRIPTION
In level 13 inside hint3 there is port 8080 should be 80 as in solution.