### PR TITLE
Add support for k3s

### DIFF
--- a/engine/engine.py
+++ b/engine/engine.py
@@ -70,7 +70,11 @@ except ImportError:
     SAFETY_ENABLED = False
     print("⚠️  Warning: Safety guards module not found. Running without protection.")
 
+# Web-mode / multi-user settings — injected by the engine pod at session creation.
+# When running locally these are unset and the game behaves exactly as before.
 K8SQUEST_NAMESPACE = os.environ.get("K8SQUEST_NAMESPACE", "k8squest")
+K8SQUEST_WEB = os.environ.get("K8SQUEST_WEB", "").lower() in ("1", "true")
+K8SQUEST_LEVEL = os.environ.get("K8SQUEST_LEVEL", "")
 K8S_CLUSTER_TYPE = os.environ.get("K8S_CLUSTER_TYPE", "kind")
 
 if not os.environ.get("KUBECONFIG"):
@@ -672,22 +676,37 @@ class K8sQuest:
         return "Checking..."
 
     def show_terminal_instructions(self, level_name):
-        """Show clear instructions about opening another terminal"""
-        instructions = Panel(
-            Text.from_markup(
-                "[bold yellow]📟 OPEN A NEW TERMINAL WINDOW[/bold yellow]\n\n"
-                "[cyan]While this game is running:[/cyan]\n"
-                "1️⃣  Open a NEW terminal window/tab\n"
-                "2️⃣  Use kubectl commands to fix the issue:\n"
-                "    • [dim]kubectl edit, scale, patch, etc.[/dim]\n"
-                "    • [dim]Or apply solution.yaml from level folder[/dim]\n"
-                "3️⃣  Come back here and choose 'validate' or 'check'\n\n"
-                "[dim]💡 Tip: Use Cmd+T (Mac) or Ctrl+Shift+T (Linux) to open a new tab[/dim]"
-            ),
-            title="[bold red]⚠️  IMPORTANT[/bold red]",
-            border_style="red",
-            box=box.DOUBLE,
-        )
+        """Show clear instructions about the kubectl terminal"""
+        if K8SQUEST_WEB:
+            # In web mode, the second terminal panel is already visible in the browser
+            instructions = Panel(
+                Text.from_markup(
+                    "[bold cyan]🖥️  USE THE RIGHT TERMINAL PANEL[/bold cyan]\n\n"
+                    "[cyan]The shell panel on the right is your kubectl workspace:[/cyan]\n"
+                    f"1️⃣  Use kubectl commands targeting namespace [bold]{K8SQUEST_NAMESPACE}[/bold]\n"
+                    "2️⃣  Fix the broken resources\n"
+                    "3️⃣  Come back here and choose 'validate' or 'check'"
+                ),
+                title="[bold yellow]⚡ YOUR WORKSPACE[/bold yellow]",
+                border_style="yellow",
+                box=box.DOUBLE,
+            )
+        else:
+            instructions = Panel(
+                Text.from_markup(
+                    "[bold yellow]📟 OPEN A NEW TERMINAL WINDOW[/bold yellow]\n\n"
+                    "[cyan]While this game is running:[/cyan]\n"
+                    "1️⃣  Open a NEW terminal window/tab\n"
+                    "2️⃣  Use kubectl commands to fix the issue:\n"
+                    "    • [dim]kubectl edit, scale, patch, etc.[/dim]\n"
+                    "    • [dim]Or apply solution.yaml from level folder[/dim]\n"
+                    "3️⃣  Come back here and choose 'validate' or 'check'\n\n"
+                    "[dim]💡 Tip: Use Cmd+T (Mac) or Ctrl+Shift+T (Linux) to open a new tab[/dim]"
+                ),
+                title="[bold red]⚠️  IMPORTANT[/bold red]",
+                border_style="red",
+                box=box.DOUBLE,
+            )
         console.print(instructions)
         console.print()
 
@@ -950,7 +969,13 @@ Look for "2/2" ready replicas!
                 mission["xp"],
                 mission.get("difficulty", "beginner"),
             )
-            wait_for_any_key()  # Wait for player to press any key (incl. space bar)
+            if K8SQUEST_WEB:
+                try:
+                    input()
+                except EOFError:
+                    return False
+            else:
+                wait_for_any_key()  # Wait for player to press any key (incl. space bar)
 
         # Show mission briefing with metadata
         console.clear()
@@ -993,19 +1018,20 @@ Look for "2/2" ready replicas!
 
         self.show_mission_briefing(mission, level_name)
 
-        # Deploy the mission
-        deployment_success = self.deploy_mission(level_path, level_name)
-        if not deployment_success:
-            console.print("\n[red]⚠️  Mission deployment failed![/red]")
-            console.print("[yellow]This usually means:[/yellow]")
-            console.print(f"  1. kubectl context is not set to '{get_expected_context()}'")
-            console.print(f"  2. {K8S_CLUSTER_TYPE.capitalize()} cluster is not running")
-            console.print("  3. Docker is not running")
-            console.print()
-            if Confirm.ask("Would you like to skip this level?", default=False):
-                return True
-            else:
-                return False
+        # In web mode the backend already deployed the namespace + broken resources
+        if not K8SQUEST_WEB:
+            deployment_success = self.deploy_mission(level_path, level_name)
+            if not deployment_success:
+                console.print("\n[red]⚠️  Mission deployment failed![/red]")
+                console.print("[yellow]This usually means:[/yellow]")
+                console.print(f"  1. kubectl context is not set to '{get_expected_context()}'")
+                console.print(f"  2. {K8S_CLUSTER_TYPE.capitalize()} cluster is not running")
+                console.print("  3. Docker is not running")
+                console.print()
+                if Confirm.ask("Would you like to skip this level?", default=False):
+                    return True
+                else:
+                    return False
 
         # Show terminal instructions prominently
         self.show_terminal_instructions(level_name)
@@ -1040,19 +1066,23 @@ Look for "2/2" ready replicas!
 
             console.print()
 
-            action = Prompt.ask(
-                "⚔️  Choose your action",
-                choices=[
-                    "check",
-                    "guide",
-                    "hints",
-                    "solution",
-                    "validate",
-                    "skip",
-                    "quit",
-                ],
-                default="check",
-            )
+            try:
+                action = Prompt.ask(
+                    "⚔️  Choose your action",
+                    choices=[
+                        "check",
+                        "guide",
+                        "hints",
+                        "solution",
+                        "validate",
+                        "skip",
+                        "quit",
+                    ],
+                    default="check",
+                )
+            except EOFError:
+                console.print("\n[yellow]Session disconnected.[/yellow]")
+                return False
 
             if action == "check":
                 # Real-time status monitoring
@@ -1164,6 +1194,17 @@ Look for "2/2" ready replicas!
                     "\n[yellow]👋 Thanks for playing K8sQuest! Progress saved.[/yellow]\n"
                 )
                 sys.exit(0)
+
+    def play_specific_level_by_name(self, level_name: str):
+        """Web mode: jump directly to a level by its directory name (e.g. 'level-1-pods')."""
+        import re
+        base_dir = Path(__file__).parent.parent / "worlds"
+        matches = list(base_dir.rglob(level_name))
+        if not matches:
+            console.print(f"[red]Level '{level_name}' not found.[/red]")
+            sys.exit(1)
+        level_path = matches[0]
+        self.play_level(level_path, level_name)
 
     def play_specific_level(self):
         """Allow user to select and play a specific level"""
@@ -1361,6 +1402,16 @@ Look for "2/2" ready replicas!
 def main():
     game = K8sQuest()
 
+    # Web mode: bypass all menus and jump straight to the requested level.
+    # K8SQUEST_LEVEL is set by the backend when creating the engine pod.
+    if K8SQUEST_WEB:
+        if K8SQUEST_LEVEL:
+            game.play_specific_level_by_name(K8SQUEST_LEVEL)
+        else:
+            console.print("[red]K8SQUEST_WEB is set but K8SQUEST_LEVEL is missing.[/red]")
+            sys.exit(1)
+        return
+
     # First time setup - get player name
     if game.progress["player_name"] == "Padawan":
         console.print()
@@ -1457,3 +1508,10 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         console.print("\n\n[yellow]👋 Game interrupted. Progress saved![/yellow]\n")
         sys.exit(0)
+    except EOFError:
+        sys.exit(0)
+    except Exception as e:
+        console.print(f"\n[bold red]Fatal error:[/bold red] {e}")
+        import traceback
+        console.print(f"[dim]{traceback.format_exc()}[/dim]")
+        sys.exit(1)

--- a/engine/engine.py
+++ b/engine/engine.py
@@ -70,6 +70,22 @@ except ImportError:
     SAFETY_ENABLED = False
     print("⚠️  Warning: Safety guards module not found. Running without protection.")
 
+K8SQUEST_NAMESPACE = os.environ.get("K8SQUEST_NAMESPACE", "k8squest")
+K8S_CLUSTER_TYPE = os.environ.get("K8S_CLUSTER_TYPE", "kind")
+
+if not os.environ.get("KUBECONFIG"):
+    home = os.path.expanduser("~")
+    if K8S_CLUSTER_TYPE == "k3s":
+        k3s_config = os.path.join(home, ".kube", "k3s-config")
+        if os.path.exists(k3s_config):
+            os.environ["KUBECONFIG"] = k3s_config
+
+def get_expected_context():
+    """Return the expected kubectl context name based on cluster type."""
+    if K8S_CLUSTER_TYPE == "k3s":
+        return "k3s-k8squest"
+    return "kind-k8squest"
+
 console = Console()
 
 
@@ -101,6 +117,10 @@ def wait_for_any_key():
                 sys.stdin.read(2)
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+            try:
+                termios.tcflush(fd, termios.TCIFLUSH)
+            except Exception:
+                pass
 
 
 class PaginatedDisplay:
@@ -155,6 +175,10 @@ class PaginatedDisplay:
                 return ch
             finally:
                 termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+                try:
+                    termios.tcflush(fd, termios.TCIFLUSH)
+                except Exception:
+                    pass
 
     @staticmethod
     def _build_code_block_states(lines):
@@ -600,7 +624,7 @@ class K8sQuest:
 
             for resource_type in resource_types:
                 result = subprocess.run(
-                    ["kubectl", "get", resource_type, "-n", "k8squest", "--no-headers"],
+                    ["kubectl", "get", resource_type, "-n", K8SQUEST_NAMESPACE, "--no-headers"],
                     capture_output=True,
                     text=True,
                     timeout=3,
@@ -764,6 +788,19 @@ Look for "2/2" ready replicas!
         """Deploy the broken Kubernetes resources"""
         console.print("\n[yellow]🚀 Deploying mission environment...[/yellow]")
 
+        # Pre-flight connectivity check with timeout
+        check = subprocess.run(
+            ["kubectl", "get", "nodes", "--request-timeout=5s"],
+            capture_output=True, text=True,
+        )
+        if check.returncode != 0:
+            console.print(f"\n[red]⚠️  Cannot connect to cluster:[/red]")
+            console.print(f"[dim red]{check.stderr.strip()}[/dim red]")
+            console.print(f"\n[yellow]💡 Make sure k3s is running, then in your other terminal run:[/yellow]")
+            console.print(f"[dim]    export KUBECONFIG=\"$HOME/.kube/k3s-config\"[/dim]")
+            console.print(f"[dim]    kubectl config use-context {get_expected_context()}[/dim]")
+            return False
+
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
@@ -772,18 +809,11 @@ Look for "2/2" ready replicas!
         ) as progress:
             task = progress.add_task("Setting up namespace...", total=3)
 
-            # Delete and recreate namespace
+            # Ensure namespace exists (idempotent, skip if already there)
             result = subprocess.run(
-                ["kubectl", "delete", "namespace", "k8squest", "--ignore-not-found"],
-                capture_output=True,
-                text=True,
-            )
-            progress.advance(task)
-
-            result = subprocess.run(
-                ["kubectl", "create", "namespace", "k8squest"],
-                capture_output=True,
-                text=True,
+                ["kubectl", "apply", "-f", "-"],
+                input="apiVersion: v1\nkind: Namespace\nmetadata:\n  name: k8squest\n",
+                capture_output=True, text=True,
             )
             
             # Check for namespace creation errors
@@ -791,9 +821,16 @@ Look for "2/2" ready replicas!
                 console.print(f"\n[red]⚠️  Failed to create namespace:[/red]")
                 console.print(f"[dim red]{result.stderr}[/dim red]")
                 console.print("[yellow]💡 Hint: Make sure your kubectl context is set correctly[/yellow]")
-                console.print("[dim]Run: kubectl config use-context kind-k8squest[/dim]")
+                console.print(f"[dim]Run: kubectl config use-context {get_expected_context()}[/dim]")
                 return False
-            
+
+            # Clean up resources from previous level (without deleting the namespace)
+            progress.update(task, description="Cleaning up previous level...")
+            subprocess.run(
+                ["kubectl", "delete", "all", "--all", "-n", K8SQUEST_NAMESPACE, "--ignore-not-found"],
+                capture_output=True, text=True,
+            )
+
             progress.update(task, description="Deploying broken resources...")
             progress.advance(task)
 
@@ -864,7 +901,7 @@ Look for "2/2" ready replicas!
             text=True,
             encoding="utf-8",
             errors="replace",
-            env={**os.environ}  # Pass through environment variables
+            env={**os.environ, "NAMESPACE": K8SQUEST_NAMESPACE}  # inject namespace for validate.sh
         )
 
         # Always show output for debugging
@@ -958,16 +995,13 @@ Look for "2/2" ready replicas!
 
         # Deploy the mission
         deployment_success = self.deploy_mission(level_path, level_name)
-        
-        # If deployment failed, offer to retry or skip
         if not deployment_success:
             console.print("\n[red]⚠️  Mission deployment failed![/red]")
             console.print("[yellow]This usually means:[/yellow]")
-            console.print("  1. kubectl context is not set to 'kind-k8squest'")
-            console.print("  2. Kind cluster is not running")
+            console.print(f"  1. kubectl context is not set to '{get_expected_context()}'")
+            console.print(f"  2. {K8S_CLUSTER_TYPE.capitalize()} cluster is not running")
             console.print("  3. Docker is not running")
             console.print()
-            
             if Confirm.ask("Would you like to skip this level?", default=False):
                 return True
             else:

--- a/k3s-setup.sh
+++ b/k3s-setup.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Setup k3s to be compatible with K8sQuest levels
+# This script creates the expected storage classes and configurations
+
+set -e
+
+echo "🔧 Setting up k3s for K8sQuest compatibility..."
+
+# Check if k3s is running
+if ! systemctl is-active --quiet k3s; then
+    echo "❌ k3s is not running. Please start k3s first."
+    exit 1
+fi
+
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
+# Create 'standard' storage class to match kind's default
+echo "📦 Creating 'standard' storage class..."
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: standard
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+EOF
+
+# Create 'fast' storage class for levels that need it
+echo "📦 Creating 'fast' storage class..."
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: fast
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+EOF
+
+# Create 'premium-ssd' storage class
+echo "📦 Creating 'premium-ssd' storage class..."
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: premium-ssd
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+EOF
+
+# Make 'local-path' non-default and 'standard' the default
+echo "🔧 Setting 'standard' as default storage class..."
+kubectl annotate sc local-path storageclass.kubernetes.io/is-default-class-
+kubectl annotate sc standard storageclass.kubernetes.io/is-default-class=true
+
+# Verify setup
+echo ""
+echo "✅ k3s setup complete! Storage classes available:"
+kubectl get storageclass
+
+echo ""
+echo "📊 Node information:"
+kubectl get nodes -o wide
+
+echo ""
+echo "✅ k3s is now compatible with K8sQuest levels!"

--- a/play.sh
+++ b/play.sh
@@ -3,8 +3,206 @@
 
 cd "$(dirname "$0")"
 
-if [ ! -d "venv" ]; then
-  echo "❌ Virtual environment not found. Please run ./install.sh first"
+# Resolve the Python interpreter to use, in priority order:
+_find_python() {
+  if [ -n "$CONDA_PREFIX" ]; then
+    if   [ -f "$CONDA_PREFIX/bin/python3" ]; then echo "$CONDA_PREFIX/bin/python3"; return
+    elif [ -f "$CONDA_PREFIX/bin/python"  ]; then echo "$CONDA_PREFIX/bin/python";  return
+    fi
+  fi
+  if [ -n "$VIRTUAL_ENV" ]; then
+    if   [ -f "$VIRTUAL_ENV/bin/python3"       ]; then echo "$VIRTUAL_ENV/bin/python3";       return
+    elif [ -f "$VIRTUAL_ENV/Scripts/python.exe" ]; then echo "$VIRTUAL_ENV/Scripts/python.exe"; return
+    fi
+  fi
+  if   [ -f "venv/bin/python3"       ]; then echo "venv/bin/python3";       return
+  elif [ -f "venv/Scripts/python.exe" ]; then echo "venv/Scripts/python.exe"; return
+  fi
+}
+
+# Function to check if a cluster is already running
+_check_existing_clusters() {
+  local has_kind=false
+  local has_k3s=false
+
+  # Check for kind clusters
+  if command -v kind &> /dev/null; then
+    if kind get clusters 2>/dev/null | grep -q .; then
+      has_kind=true
+    fi
+  fi
+
+  # Check for k3s
+  if systemctl is-active --quiet k3s 2>/dev/null; then
+    has_k3s=true
+  elif [ -f /etc/rancher/k3s/k3s.yaml ] && kubectl --kubeconfig=/etc/rancher/k3s/k3s.yaml get nodes &> /dev/null; then
+    has_k3s=true
+  fi
+
+  if $has_kind && $has_k3s; then
+    echo "both"
+  elif $has_kind; then
+    echo "kind"
+  elif $has_k3s; then
+    echo "k3s"
+  else
+    echo "none"
+  fi
+}
+
+# Function to set up k3s kubeconfig
+_setup_k3s_kubeconfig() {
+  local default_kubeconfig="/etc/rancher/k3s/k3s.yaml"
+  
+  # Check if k3s is running
+  if ! systemctl is-active --quiet k3s 2>/dev/null; then
+    echo "ℹ️  k3s is installed but not running. Starting..."
+    sudo systemctl start k3s
+    echo "⏳ Waiting for k3s to start..."
+    local k3s_attempt=0
+    until timeout 10 k3s kubectl get nodes &> /dev/null; do
+      k3s_attempt=$((k3s_attempt + 1))
+      if [ $k3s_attempt -ge 90 ]; then
+        echo "❌ k3s failed to start within 3 minutes"
+        return 1
+      fi
+      sleep 2
+    done
+  fi
+  
+  # Ask for custom kubeconfig path
+  echo ""
+  echo "Default k3s kubeconfig location: $default_kubeconfig"
+  echo "Note: This file requires root permissions to read."
+  read -p "Enter custom path for kubeconfig (or press Enter for default: $HOME/.kube/k3s-config): " CUSTOM_KUBECONFIG
+  
+  if [ -z "$CUSTOM_KUBECONFIG" ]; then
+    CUSTOM_KUBECONFIG="$HOME/.kube/k3s-config"
+  fi
+  
+  # If custom path is not the default, copy it
+  if [ "$CUSTOM_KUBECONFIG" != "$default_kubeconfig" ]; then
+    echo "ℹ️  Using custom kubeconfig path: $CUSTOM_KUBECONFIG"
+    echo "📦 Copying k3s kubeconfig to $CUSTOM_KUBECONFIG..."
+    mkdir -p "$(dirname "$CUSTOM_KUBECONFIG")"
+    sudo cp "$default_kubeconfig" "$CUSTOM_KUBECONFIG"
+    sudo chown "$USER:$USER" "$CUSTOM_KUBECONFIG"
+    export KUBECONFIG="$CUSTOM_KUBECONFIG"
+  else
+    # Copy to user-accessible location anyway
+    echo "📦 Copying k3s kubeconfig to $HOME/.kube/k3s-config..."
+    mkdir -p "$HOME/.kube"
+    sudo cp "$default_kubeconfig" "$HOME/.kube/k3s-config"
+    sudo chown "$USER:$USER" "$HOME/.kube/k3s-config"
+    export KUBECONFIG="$HOME/.kube/k3s-config"
+  fi
+  
+  _rename_k3s_context "$KUBECONFIG"
+
+  # Symlink default kubeconfig so new terminals auto-use this config
+  if [ -f "$HOME/.kube/config" ] && [ ! -L "$HOME/.kube/config" ]; then
+    cp "$HOME/.kube/config" "$HOME/.kube/config.k8squest.bak"
+    echo "ℹ️  Backed up ~/.kube/config → ~/.kube/config.k8squest.bak (your existing config is preserved there)"
+  fi
+  ln -snf "$KUBECONFIG" "$HOME/.kube/config"
+
+  echo "✅ k3s cluster is ready (kubeconfig: $KUBECONFIG)"
+}
+
+# Rename k3s context from 'default' to 'k3s-k8squest'
+_rename_k3s_context() {
+  local kubeconfig="$1"
+  local new_ctx="k3s-k8squest"
+  local tmp_dir="/tmp/k8squest-k3s-$$"
+
+  [ ! -f "$kubeconfig" ] && return
+
+  local cur_ctx
+  cur_ctx=$(kubectl --kubeconfig="$kubeconfig" config view -o jsonpath='{.current-context}' 2>/dev/null)
+  [ "$cur_ctx" = "$new_ctx" ] && return
+
+  echo "🔄 Renaming k3s context from '$cur_ctx' to '$new_ctx'..."
+
+  local json
+  json=$(kubectl --kubeconfig="$kubeconfig" config view --raw -o json 2>/dev/null)
+
+  local server ca_data cert_data key_data
+  server=$(echo "$json" | jq -r --arg ctx "$cur_ctx" '.clusters[] | select(.name==$ctx) | .cluster.server')
+  ca_data=$(echo "$json" | jq -r --arg ctx "$cur_ctx" '.clusters[] | select(.name==$ctx) | .cluster["certificate-authority-data"] // empty')
+  cert_data=$(echo "$json" | jq -r --arg ctx "$cur_ctx" '.users[] | select(.name==$ctx) | .user["client-certificate-data"] // empty')
+  key_data=$(echo "$json" | jq -r --arg ctx "$cur_ctx" '.users[] | select(.name==$ctx) | .user["client-key-data"] // empty')
+
+  if [ -z "$server" ]; then
+    echo "❌ Failed to extract cluster '$cur_ctx' from kubeconfig"
+    return 1
+  fi
+
+  # Write cert data to temp files (old kubectl doesn't have --*-data flags)
+  mkdir -p "$tmp_dir"
+  echo "$ca_data" | tr -d '\n' | base64 -d > "$tmp_dir/ca.crt" 2>/dev/null
+  echo "$cert_data" | tr -d '\n' | base64 -d > "$tmp_dir/client.crt" 2>/dev/null
+  echo "$key_data" | tr -d '\n' | base64 -d > "$tmp_dir/client.key" 2>/dev/null
+
+  kubectl --kubeconfig="$kubeconfig" config set-cluster "$new_ctx" \
+    --server="$server" --certificate-authority="$tmp_dir/ca.crt" --embed-certs
+
+  kubectl --kubeconfig="$kubeconfig" config set-credentials "$new_ctx" \
+    --client-certificate="$tmp_dir/client.crt" --client-key="$tmp_dir/client.key" --embed-certs
+
+  kubectl --kubeconfig="$kubeconfig" config set-context "$new_ctx" \
+    --cluster="$new_ctx" --user="$new_ctx" --namespace="k8squest"
+
+  kubectl --kubeconfig="$kubeconfig" config use-context "$new_ctx"
+
+  rm -rf "$tmp_dir"
+}
+
+# Function to install k3s
+_install_k3s() {
+  echo "🔧 Setting up k3s cluster..."
+  if ! command -v k3s &> /dev/null; then
+    # Remove any dangling kubectl symlink from a previous uninstall
+    if [ -L /usr/local/bin/kubectl ] && [ ! -e /usr/local/bin/kubectl ]; then
+      echo "🧹 Removing stale kubectl symlink..."
+      sudo rm -f /usr/local/bin/kubectl
+    fi
+    echo "📦 Installing k3s..."
+    curl -sfL https://get.k3s.io | sh -s - server \
+      --cluster-init \
+      --disable traefik \
+      --write-kubeconfig-mode 644
+    if [ $? -ne 0 ]; then
+      echo "❌ Failed to install k3s"
+      exit 1
+    fi
+    hash -r
+    echo "⏳ Waiting for k3s to start..."
+    local k3s_attempt=0
+    until timeout 10 k3s kubectl get nodes &> /dev/null; do
+      k3s_attempt=$((k3s_attempt + 1))
+      if [ $k3s_attempt -ge 90 ]; then
+        echo "❌ k3s failed to start within 3 minutes"
+        exit 1
+      fi
+      sleep 2
+    done
+  else
+    echo "ℹ️  k3s is already installed. Starting service if not running..."
+    sudo systemctl start k3s || true
+  fi
+  _setup_k3s_kubeconfig
+  
+  # Run k3s compatibility setup
+  if [ -f "$(dirname "$0")/k3s-setup.sh" ]; then
+    echo "🔧 Running k3s compatibility setup for K8sQuest..."
+    bash "$(dirname "$0")/k3s-setup.sh"
+  fi
+}
+
+PYTHON=$(_find_python)
+if [ -z "$PYTHON" ]; then
+  echo "❌ No Python environment found. Please run ./install.sh first"
+  echo "   Supported: conda env, virtualenv, or project venv (created by install.sh)"
   exit 1
 fi
 
@@ -32,12 +230,124 @@ fi
 # Set PYTHONPATH to include the project root
 export PYTHONPATH="$(pwd):$PYTHONPATH"
 
-# Use venv Python directly (cross-platform)
-if [ -f "venv/bin/python3" ]; then
-  venv/bin/python3 engine/engine.py
-elif [ -f "venv/Scripts/python.exe" ]; then
-  venv/Scripts/python.exe engine/engine.py
+# Check for existing clusters
+EXISTING_CLUSTER=$(_check_existing_clusters)
+
+if [ "$EXISTING_CLUSTER" != "none" ] && [ -z "$K8S_CLUSTER_TYPE" ]; then
+  echo ""
+  echo "╔══════════════════════════════════════════════════════════════╗"
+  echo "║  ⚠️  Detected existing $EXISTING_CLUSTER cluster(s) running!  ║"
+  echo "╚══════════════════════════════════════════════════════════════╝"
+  echo ""
+  if [ "$EXISTING_CLUSTER" = "both" ]; then
+    echo "📊 Both 🐳 kind and 🚀 k3s clusters are detected."
+    echo ""
+    echo "  Options:"
+    echo "    1) 🐳 Use existing kind cluster"
+    echo "    2) 🚀 Use existing k3s cluster"
+    echo "    3) 🔄 Reinstall/restart k3s (will not affect kind)"
+    echo "    4) ⏭️  Continue without changes (use current kubectl context)"
+    echo ""
+    read -p "  Select option [1-4] (default: 1): " CLUSTER_CHOICE
+    case $CLUSTER_CHOICE in
+      2)
+        echo "  ✅ Using existing k3s cluster"
+        export K8S_CLUSTER_TYPE=k3s
+        _setup_k3s_kubeconfig
+        ;;
+      3)
+        export K8S_CLUSTER_TYPE=k3s
+        _install_k3s
+        ;;
+      4)
+        echo "  ✅ Using current kubectl context"
+        ;;
+      *)
+        echo "  ✅ Using existing kind cluster"
+        export K8S_CLUSTER_TYPE=kind
+        ;;
+    esac
+  else
+    echo "  📊 An existing 🐳 $EXISTING_CLUSTER cluster is detected."
+    echo ""
+    read -p "  Do you want to use the existing $EXISTING_CLUSTER cluster? [Y/n]: " USE_EXISTING
+    case $USE_EXISTING in
+      [Nn]*)
+        if [ "$EXISTING_CLUSTER" = "k3s" ]; then
+          export K8S_CLUSTER_TYPE=k3s
+          _install_k3s
+        else
+          echo "  ✅ Using kind cluster"
+          export K8S_CLUSTER_TYPE=kind
+        fi
+        ;;
+      *)
+        echo "  ✅ Using existing $EXISTING_CLUSTER cluster"
+        if [ "$EXISTING_CLUSTER" = "k3s" ]; then
+          export K8S_CLUSTER_TYPE=k3s
+          _setup_k3s_kubeconfig
+        else
+          export K8S_CLUSTER_TYPE=kind
+        fi
+        ;;
+    esac
+  fi
 else
-  echo "❌ Virtual environment Python not found"
-  exit 1
+  # Cluster selection prompt (only if no existing cluster detected or K8S_CLUSTER_TYPE is set)
+  if [ -z "$K8S_CLUSTER_TYPE" ]; then
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════════════╗"
+    echo "║          🎮 SELECT YOUR KUBERNETES CLUSTER TYPE 🎮             ║"
+    echo "╚══════════════════════════════════════════════════════════════════╝"
+    echo ""
+    echo "  1) 🐳 kind  - Multi-node clusters in Docker containers"
+    echo "     └─ Perfect for: Learning, development, CI/CD pipelines"
+    echo "     └─ Pros: Easy setup, runs anywhere Docker runs, fast reset"
+    echo "     └─ Cons: Requires Docker, not production-like networking"
+    echo ""
+    echo "  2) 🚀 k3s  - Lightweight production-ready Kubernetes"
+    echo "     └─ Perfect for: Edge, IoT, local production-like testing"
+    echo "     └─ Pros: Real cluster, no Docker needed, closer to production"
+    echo "     └─ Cons: Uses system resources, single-node by default"
+    echo ""
+    read -p "Select cluster type [1/2] (default: kind): " CLUSTER_CHOICE
+    case $CLUSTER_CHOICE in
+      2|k3s|K3s)
+        export K8S_CLUSTER_TYPE=k3s
+        _install_k3s
+        ;;
+      *)
+        echo "✅ Using kind cluster"
+        export K8S_CLUSTER_TYPE=kind
+        ;;
+    esac
+  fi
 fi
+
+# When using kind, remove k3s symlink to restore default kubeconfig
+_remove_k3s_symlink() {
+  local default_kube="$HOME/.kube/config"
+  if [ -L "$default_kube" ]; then
+    local target
+    target="$(readlink "$default_kube")"
+    if [ "$target" = "k3s-config" ] || [ "$target" = "$HOME/.kube/k3s-config" ]; then
+      rm "$default_kube"
+      if [ -f "$HOME/.kube/config.k8squest.bak" ]; then
+        mv "$HOME/.kube/config.k8squest.bak" "$default_kube"
+        echo "ℹ️  Restored ~/.kube/config from backup (~/.kube/config.k8squest.bak)"
+      fi
+    fi
+  fi
+}
+
+if [ "${K8S_CLUSTER_TYPE:-}" = "kind" ]; then
+  _remove_k3s_symlink
+fi
+
+# Ensure KUBECONFIG is set for the engine
+if [ "$K8S_CLUSTER_TYPE" = "k3s" ] && [ -z "${KUBECONFIG:-}" ] && [ -f "$HOME/.kube/k3s-config" ]; then
+  export KUBECONFIG="$HOME/.kube/k3s-config"
+  echo "ℹ️  Using kubeconfig: $KUBECONFIG"
+fi
+
+"$PYTHON" engine/engine.py

--- a/worlds/world-5-security/level-45-node-affinity/setup.sh
+++ b/worlds/world-5-security/level-45-node-affinity/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Setup script for level 45 - Node Affinity
+# Labels a node with accelerator=gpu for the affinity rule
+
+set -e
+
+NAMESPACE=${1:-k8squest}
+echo "🔧 Setting up Node Affinity level..."
+
+# Get the first node (works for both kind and k3s)
+NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+
+if [ -z "$NODE_NAME" ]; then
+    echo "❌ No nodes found in the cluster"
+    exit 1
+fi
+
+echo "📍 Found node: $NODE_NAME"
+
+# Label the node for GPU workload affinity
+echo "🏷️  Labeling node $NODE_NAME with accelerator=gpu..."
+kubectl label node "$NODE_NAME" accelerator=gpu --overwrite
+
+# Verify the label
+echo "✅ Node labels:"
+kubectl get node "$NODE_NAME" --show-labels
+
+echo ""
+echo "✅ Setup complete! Node is ready for GPU workload scheduling."

--- a/worlds/world-5-security/level-46-taints-tolerations/setup.sh
+++ b/worlds/world-5-security/level-46-taints-tolerations/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Setup script for level 46 - Taints and Tolerations
+# Taints a node with dedicated=gpu:NoSchedule
+
+set -e
+
+NAMESPACE=${1:-k8squest}
+echo "🔧 Setting up Taints and Tolerations level..."
+
+# Get the first node (works for both kind and k3s)
+NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+
+if [ -z "$NODE_NAME" ]; then
+    echo "❌ No nodes found in the cluster"
+    exit 1
+fi
+
+echo "📍 Found node: $NODE_NAME"
+
+# Taint the node to simulate dedicated GPU node
+echo "🚧 Tainting node $NODE_NAME with dedicated=gpu:NoSchedule..."
+kubectl taint nodes "$NODE_NAME" dedicated=gpu:NoSchedule --overwrite
+
+# Verify the taint
+echo "✅ Node taints:"
+kubectl get node "$NODE_NAME" -o jsonpath='{.spec.taints}' | jq .
+
+echo ""
+echo "✅ Setup complete! Node is tainted - pods need tolerations to schedule."

--- a/worlds/world-5-security/level-46-taints-tolerations/setup.sh
+++ b/worlds/world-5-security/level-46-taints-tolerations/setup.sh
@@ -23,7 +23,8 @@ kubectl taint nodes "$NODE_NAME" dedicated=gpu:NoSchedule --overwrite
 
 # Verify the taint
 echo "✅ Node taints:"
-kubectl get node "$NODE_NAME" -o jsonpath='{.spec.taints}' | jq .
+kubectl get node "$NODE_NAME" -o jsonpath='{.spec.taints}'
+echo ""
 
 echo ""
 echo "✅ Setup complete! Node is tainted - pods need tolerations to schedule."

--- a/worlds/world-5-security/level-50-chaos-finale/setup.sh
+++ b/worlds/world-5-security/level-50-chaos-finale/setup.sh
@@ -27,7 +27,8 @@ kubectl label node "$NODE_NAME" accelerator=gpu --overwrite
 
 # Verify the setup
 echo "✅ Node taints:"
-kubectl get node "$NODE_NAME" -o jsonpath='{.spec.taints}' | jq .
+kubectl get node "$NODE_NAME" -o jsonpath='{.spec.taints}'
+echo ""
 
 echo ""
 echo "✅ Node labels:"

--- a/worlds/world-5-security/level-50-chaos-finale/setup.sh
+++ b/worlds/world-5-security/level-50-chaos-finale/setup.sh
@@ -22,7 +22,7 @@ echo "🚧 Tainting node $NODE_NAME with dedicated=gpu:NoSchedule..."
 kubectl taint nodes "$NODE_NAME" dedicated=gpu:NoSchedule --overwrite
 
 # Label the node for affinity
-echo "🏷️  Labeling node $NODE_NAME with accelerator=gpu...""
+echo "🏷️  Labeling node $NODE_NAME with accelerator=gpu..."
 kubectl label node "$NODE_NAME" accelerator=gpu --overwrite
 
 # Verify the setup

--- a/worlds/world-5-security/level-50-chaos-finale/setup.sh
+++ b/worlds/world-5-security/level-50-chaos-finale/setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Setup script for level 50 - Chaos Finale
+# Taints a node and sets up the chaos scenario
+
+set -e
+
+NAMESPACE=${1:-k8squest}
+echo "🔧 Setting up Chaos Finale level..."
+
+# Get the first node (works for both kind and k3s)
+NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+
+if [ -z "$NODE_NAME" ]; then
+    echo "❌ No nodes found in the cluster"
+    exit 1
+fi
+
+echo "📍 Found node: $NODE_NAME"
+
+# Taint the node to simulate dedicated GPU node
+echo "🚧 Tainting node $NODE_NAME with dedicated=gpu:NoSchedule..."
+kubectl taint nodes "$NODE_NAME" dedicated=gpu:NoSchedule --overwrite
+
+# Label the node for affinity
+echo "🏷️  Labeling node $NODE_NAME with accelerator=gpu...""
+kubectl label node "$NODE_NAME" accelerator=gpu --overwrite
+
+# Verify the setup
+echo "✅ Node taints:"
+kubectl get node "$NODE_NAME" -o jsonpath='{.spec.taints}' | jq .
+
+echo ""
+echo "✅ Node labels:"
+kubectl get node "$NODE_NAME" --show-labels
+
+echo ""
+echo "✅ Setup complete! Chaos scenario is ready."


### PR DESCRIPTION
Hi @manojaryan 

# Pull Request

## 📝 Description
Add Support and Option to deploy a k3s cluster

1. play.sh (Enhanced):
- Fun cluster selection menu with explanations
- Checks for existing clusters before prompting
- Prompts for custom kubeconfig path (defaults to $HOME/.kube/k3s-config)
- Sets K8S_CLUSTER_TYPE environment variable
- Runs k3s-setup.sh automatically after install
2. engine/engine.py (Updated):
- Uses K8S_CLUSTER_TYPE env var (defaults to "kind")
- get_expected_context() returns k3s-k8squest or kind-k8squest
- Updated all hardcoded "kind-k8squest" references
3. k3s-setup.sh (New):
- Creates standard storage class (matches kind's default)
- Creates fast & premium-ssd storage classes
- Sets standard as default storage class
- Makes storage levels (31, 32, 33, 34, 35, 39) work with k3s
4. Setup Scripts (New - for node-specific levels):
- level-45-node-affinity/setup.sh - Labels node with accelerator=gpu
- level-46-taints-tolerations/setup.sh - Taints node with dedicated=gpu:NoSchedule
- level-50-chaos-finale/setup.sh - Sets up both labels & taints


## 🎯 Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎮 New level/challenge
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🎨 UI/UX improvement



## 📍 Affected Levels/Areas
play.sh
engine.py

## ✅ Testing Checklist
<!-- Please check all that apply -->
- [X] I have tested this locally
- [ ] I have run the affected level(s) end-to-end
- [ ] Validation scripts pass correctly
- [ ] Hints are clear and helpful
- [ ] Solution works as intended
- [ ] Debrief explains the concept well
- [ ] No breaking changes to other levels
- [ ] Code follows the project style

## 🧪 How to Test
<!-- Describe how reviewers can test your changes -->

### clone upstream
```
git clone https://github.com/Manoj-engineer/k8squest.git

cd k8squest

git remote add dremerten https://github.com/dremerten/k8squest.git

git fetch dremerten

# checkout  PR branch

git checkout -b support_k3s dremerten/support_k3s
```

```
bash play.sh ----> select 2) (for k3s)
```
# Verify k3s 
```
kubectl get nodes -o wide
NAME           STATUS   ROLES                AGE   VERSION        INTERNAL-IP      EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION      CONTAINER-RUNTIME
k3s-cluster1   Ready    control-plane,etcd   11s   v1.35.4+k3s1   192.168.x.x   <none>        Ubuntu 24.04.4 LTS   6.8.0-111-generic   containerd://2.2.3-k3s1
```
---

### Reviewer Checklist
<!-- For maintainers -->
- [ ] Code quality is acceptable
- [ ] Changes align with K8sQuest's learning objectives
- [ ] No security concerns
- [ ] Documentation is adequate
- [ ] Tested locally and works as described
